### PR TITLE
Fix linter errors

### DIFF
--- a/org.kde.PlatformTheme.QGnomePlatform.json
+++ b/org.kde.PlatformTheme.QGnomePlatform.json
@@ -18,7 +18,7 @@
                 {
                     "type": "git",
                     "url": "https://github.com/FedoraQt/adwaita-qt.git",
-                    "branch": "1.4.2"
+                    "tag": "1.4.2"
                 },
                 {
                     "type": "shell",
@@ -40,7 +40,7 @@
                 {
                     "type": "git",
                     "url": "https://github.com/FedoraQt/QGnomePlatform.git",
-                    "branch": "0.9.0"
+                    "tag": "0.9.0"
                 },
                 {
                     "type": "patch",


### PR DESCRIPTION
This should unbreak the build of the plugin on flathub.

Same as https://github.com/flathub/org.kde.PlatformTheme.QGnomePlatform/pull/9