### PR TITLE
Create branch for Qt (and KDE Flatpak runtime) 6.6

### DIFF
--- a/org.kde.PlatformTheme.QGnomePlatform.json
+++ b/org.kde.PlatformTheme.QGnomePlatform.json
@@ -1,10 +1,10 @@
 {
     "id": "org.kde.PlatformTheme.QGnomePlatform",
-    "branch": "6.5",
+    "branch": "6.6",
     "runtime": "org.kde.Platform",
     "build-extension": true,
     "sdk": "org.kde.Sdk",
-    "runtime-version": "6.5",
+    "runtime-version": "6.6",
     "appstream-compose": false,
     "separate-locales": false,
     "modules": [


### PR DESCRIPTION
A Flatpak runtime corresponding to Qt 6.6 was recently pushed to Flathub, meaning that [apps that were recently updated to the new runtime broke GNOME styling with KDE/Qt apps, such as org.strawberrymusicplayer.strawberry](https://github.com/flathub/org.strawberrymusicplayer.strawberry/issues/65). The creation of a new branch for the new runtime _should_ remedy this.

_Should_ fix flathub/org.strawberrymusicplayer.strawberry#65.