### PR TITLE
Update to 0.9.2

### DIFF
--- a/org.kde.PlatformTheme.QGnomePlatform.json
+++ b/org.kde.PlatformTheme.QGnomePlatform.json
@@ -38,7 +38,7 @@
                 {
                     "type": "git",
                     "url": "https://github.com/FedoraQt/QGnomePlatform.git",
-                    "commit": "727ddf252bf08a7b460a844bcbe0b4cbad232b1e"
+                    "tag": "0.9.2"
                 },
                 {
                     "type": "patch",


### PR DESCRIPTION
This makes QGnomePlatform not used by default and prefer QGtk3Theme